### PR TITLE
Deploy latest tagged version with terraform

### DIFF
--- a/.github/workflows/terraform-deploy.yml
+++ b/.github/workflows/terraform-deploy.yml
@@ -3,7 +3,7 @@ name: Terraform Deploy
 
 on:
   push:
-    branches: [Terraform_Latest_Tag]
+    branches: [main]
     paths:
       - 'infrastructure/*'
       - '!infrastructure/*.md'
@@ -12,7 +12,7 @@ on:
 
 jobs:
   Terraform_Deploy:
-    uses: TheBatchelorFamily/SharedGHA/.github/workflows/terraform_deploy.yml@terraform_latest_tag
+    uses: TheBatchelorFamily/SharedGHA/.github/workflows/terraform_deploy.yml@1.1.0
     with:
       checkoutBranch: Terraform_Latest_Tag
       deployLatestTag: true

--- a/.github/workflows/terraform-deploy.yml
+++ b/.github/workflows/terraform-deploy.yml
@@ -3,7 +3,7 @@ name: Terraform Deploy
 
 on:
   push:
-    branches: [main]
+    branches: [Terraform_Latest_Tag]
     paths:
       - 'infrastructure/*'
       - '!infrastructure/*.md'
@@ -12,8 +12,9 @@ on:
 
 jobs:
   Terraform_Deploy:
-    uses: TheBatchelorFamily/SharedGHA/.github/workflows/terraform_deploy.yml@main
+    uses: TheBatchelorFamily/SharedGHA/.github/workflows/terraform_deploy.yml@terraform_latest_tag
     with:
-      checkoutBranch: main
+      checkoutBranch: Terraform_Latest_Tag
+      deployLatestTag: true
       workingDirectory: ./infrastructure/
     secrets: inherit

--- a/infrastructure/user_data.tftpl
+++ b/infrastructure/user_data.tftpl
@@ -1,6 +1,6 @@
 #!/bin/bash
 export CONTAINER INSTANCE_ID ALLOC_ID AWS_DEFAULT_REGION
-CONTAINER='fiercekitti/portfolio_website:${tag}'
+CONTAINER="fiercekitti/portfolio_website:${tag}"
 INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
 # shellcheck disable=SC2154
 ALLOC_ID="${eipID}"

--- a/infrastructure/user_data.tftpl
+++ b/infrastructure/user_data.tftpl
@@ -12,6 +12,6 @@ sudo yum update -y
 sudo amazon-linux-extras install docker -y
 sudo service docker start
 sudo usermod -a -G docker ec2-user
-docker pull $CONTAINER
-docker run -it -d -p 80:80 $CONTAINER
+docker pull "$CONTAINER"
+docker run -it -d -p 80:80 "$CONTAINER"
 aws ec2 associate-address --instance-id "$INSTANCE_ID" --allocation-id "$ALLOC_ID" --allow-reassociation

--- a/infrastructure/user_data.tftpl
+++ b/infrastructure/user_data.tftpl
@@ -1,5 +1,6 @@
 #!/bin/bash
 export CONTAINER INSTANCE_ID ALLOC_ID AWS_DEFAULT_REGION
+# shellcheck disable=SC2154
 CONTAINER="fiercekitti/portfolio_website:${tag}"
 INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
 # shellcheck disable=SC2154

--- a/infrastructure/user_data.tftpl
+++ b/infrastructure/user_data.tftpl
@@ -1,6 +1,6 @@
 #!/bin/bash
 export CONTAINER INSTANCE_ID ALLOC_ID AWS_DEFAULT_REGION
-CONTAINER='fiercekitti/portfolio_website'
+CONTAINER='fiercekitti/portfolio_website:${tag}'
 INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
 # shellcheck disable=SC2154
 ALLOC_ID="${eipID}"

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -1,6 +1,9 @@
 variable dnsName {
     default = "itsmeganificent.com"
 }
+variable imageTag {
+    default = "2.0.2"
+}
 variable itype {
     default = "t2.micro"
 }

--- a/infrastructure/webserver.tf
+++ b/infrastructure/webserver.tf
@@ -47,7 +47,7 @@ module "aws_auto_scale" {
   keyname       = var.keyname
   publicIP      = true
   securityGroup = [module.aws_webserver_network.aws_security_group_id]
-  source        = "github.com/TheBatchelorFamily/SharedTerraform.git//modules/aws_auto_scale?ref=1.0.0"
+  source        = "github.com/TheBatchelorFamily/SharedTerraform.git//modules/aws_auto_scale?ref=update_default_version"
   sshPub        = file(var.sshPub)
   subnet        = var.subnet
   tags          = var.tags

--- a/infrastructure/webserver.tf
+++ b/infrastructure/webserver.tf
@@ -55,7 +55,8 @@ module "aws_auto_scale" {
     "./user_data.tftpl",
     {
       eipID:module.aws_webserver_network.aws_eip_alloID,
-      region:var.region
+      region:var.region,
+      tag:var.imageTag
     }
   ))
 }

--- a/infrastructure/webserver.tf
+++ b/infrastructure/webserver.tf
@@ -33,7 +33,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "terraform_state" 
 }
 
 module "aws_webserver_network" {
-  source       = "github.com/TheBatchelorFamily/SharedTerraform.git//modules/aws_webserver_network?ref=1.0.0"
+  source       = "github.com/TheBatchelorFamily/SharedTerraform.git//modules/aws_webserver_network?ref=1.0.1"
   dnsName      = var.dnsName
   r53Enabled   = true
   region       = var.region
@@ -47,7 +47,7 @@ module "aws_auto_scale" {
   keyname       = var.keyname
   publicIP      = true
   securityGroup = [module.aws_webserver_network.aws_security_group_id]
-  source        = "github.com/TheBatchelorFamily/SharedTerraform.git//modules/aws_auto_scale?ref=update_default_version"
+  source        = "github.com/TheBatchelorFamily/SharedTerraform.git//modules/aws_auto_scale?ref=1.0.1"
   sshPub        = file(var.sshPub)
   subnet        = var.subnet
   tags          = var.tags


### PR DESCRIPTION
This commit will switch our deployment to use the latest tagged image version from the repo (ie 2.0.2) rather than the image version tagged "latest"