### PR TITLE
Increment auto_scale terraform module

### DIFF
--- a/infrastructure/webserver.tf
+++ b/infrastructure/webserver.tf
@@ -47,7 +47,7 @@ module "aws_auto_scale" {
   keyname       = var.keyname
   publicIP      = true
   securityGroup = [module.aws_webserver_network.aws_security_group_id]
-  source        = "github.com/TheBatchelorFamily/SharedTerraform.git//modules/aws_auto_scale?ref=1.0.1"
+  source        = "github.com/TheBatchelorFamily/SharedTerraform.git//modules/aws_auto_scale?ref=instance_refresh"
   sshPub        = file(var.sshPub)
   subnet        = var.subnet
   tags          = var.tags

--- a/infrastructure/webserver.tf
+++ b/infrastructure/webserver.tf
@@ -47,7 +47,7 @@ module "aws_auto_scale" {
   keyname       = var.keyname
   publicIP      = true
   securityGroup = [module.aws_webserver_network.aws_security_group_id]
-  source        = "github.com/TheBatchelorFamily/SharedTerraform.git//modules/aws_auto_scale?ref=instance_refresh"
+  source        = "github.com/TheBatchelorFamily/SharedTerraform.git//modules/aws_auto_scale?ref=1.0.2"
   sshPub        = file(var.sshPub)
   subnet        = var.subnet
   tags          = var.tags


### PR DESCRIPTION
I'm incrementing the auto_scale terraform module so that instance refreshes should be handled automatically whenever terraform updates the launch template. This should occur if we run the terraform deploy action after a new release is tagged to the GitHub repo.

This is pending the merge of https://github.com/TheBatchelorFamily/SharedTerraform/pull/8